### PR TITLE
Adjust minimum window size

### DIFF
--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -116,8 +116,8 @@ class MainProcess {
     const options: BrowserWindowConstructorOptions = {
       width: this.store?.get("window").width,
       height: this.store?.get("window").height,
-      minHeight: 800,
-      minWidth: 1280,
+      minHeight: 600,
+      minWidth: 800,
       // 菜单栏
       titleBarStyle: "customButtonsOnHover",
       // 立即显示窗口


### PR DESCRIPTION
## Summary
- update the Electron main window constraints to enforce an 800x600 minimum size

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dde924550883208d3977ba0a050eda